### PR TITLE
Enable extended NKRO and low-latency key-down

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0
 

--- a/config/eyelash_sofle.conf
+++ b/config/eyelash_sofle.conf
@@ -37,9 +37,16 @@ CONFIG_ZMK_EXT_POWER=y
 CONFIG_ZMK_POINTING=y
 
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
-# Enable full N-key rollover. The standard report is sufficient for this keymap
-# and avoids the compatibility cost of the extended report.
+# Enable full N-key rollover.
 CONFIG_ZMK_HID_REPORT_TYPE_NKRO=y
+# Include the complete keyboard usage range (including F13-F24 and INTL keys).
+# This can reduce HID compatibility with Android hosts.
+CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT=y
+
+# Reduce key-down latency without using the bounce-prone zero-ms eager setting.
+# Keep release debouncing conservative to avoid accidental double presses.
+CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
+CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=5
 
 CONFIG_ZMK_BACKLIGHT=y
 CONFIG_ZMK_BACKLIGHT_BRT_START=100

--- a/config/eyelash_sofle.conf
+++ b/config/eyelash_sofle.conf
@@ -37,7 +37,9 @@ CONFIG_ZMK_EXT_POWER=y
 CONFIG_ZMK_POINTING=y
 
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
-CONFIG_ZMK_HID_REPORT_TYPE_NKRO=n
+# Enable full N-key rollover. The standard report is sufficient for this keymap
+# and avoids the compatibility cost of the extended report.
+CONFIG_ZMK_HID_REPORT_TYPE_NKRO=y
 
 CONFIG_ZMK_BACKLIGHT=y
 CONFIG_ZMK_BACKLIGHT_BRT_START=100

--- a/config/west.yml
+++ b/config/west.yml
@@ -17,7 +17,7 @@ manifest:
       revision: main                           # new entry
     - name: zmk
       remote: zmkfirmware
-      revision: 461f5c8
+      revision: v0.3.0
       import: app/west.yml
   self:
     path: config

--- a/keymap-drawer/eyelash_sofle.svg
+++ b/keymap-drawer/eyelash_sofle.svg
@@ -151,25 +151,25 @@ text.footer {
 }
 
 /* styling for combo tap, and key non-tap label text */
-text.combo, text.hold, text.shifted, text.left, text.right {
+text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
     font-size: 11px;
 }
 
-text.hold {
+text.hold, text.bl, text.br {
     text-anchor: middle;
     dominant-baseline: auto;
 }
 
-text.shifted {
+text.shifted, text.tl, text.tr {
     text-anchor: middle;
     dominant-baseline: hanging;
 }
 
-text.left {
+text.left, text.tl, text.bl {
     text-anchor: start;
 }
 
-text.right {
+text.right, text.tr, text.br {
     text-anchor: end;
 }
 


### PR DESCRIPTION
Updates the firmware configuration to ZMK v0.3.0 and enables extended NKRO, including the full keyboard usage range.

The board’s diode matrix configuration is retained. Key-down debounce is reduced from ZMK’s 5 ms default to a conservative 1 ms; key-up debounce remains 5 ms to avoid bounce-related double presses. The existing nice!view battery shield, pointing-device speeds, encoder behavior, RGB/backlight settings, ZMK Studio configuration, and keymap are unchanged.

The build workflow is pinned to v0.3.0 so its build environment matches the firmware revision. Note that extended NKRO may be incompatible with Android hosts.

Validated by GitHub Actions: all left, right, and settings-reset UF2 targets built successfully.